### PR TITLE
Add tqdm progress bars

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -8,5 +8,6 @@ dependencies:
   - pytorch
   - numba
   - psutil
+  - tqdm
   - matplotlib
   - jupyterlab

--- a/src/datasets.py
+++ b/src/datasets.py
@@ -9,6 +9,7 @@ import numpy as np
 import torch
 from torch.utils.data import Dataset
 from torch.utils.data.dataloader import DataLoader
+from tqdm import tqdm
 
 from src.envs.environment import do_stats
 from src.utils import MAX_WORKERS
@@ -16,7 +17,7 @@ from src.utils import MAX_WORKERS
 logger = getLogger()
 
 
-def detokenize(data, args, env, executor=None):
+def detokenize(data, args, env, executor=None, pbar=None):
     res = []
     pars = env.tokenizer.dataclass._save_class_params()
     if args.process_pool:
@@ -27,13 +28,16 @@ def detokenize(data, args, env, executor=None):
             for chunk in executor.map(env.tokenizer.decode_batch, data_slices, repeat(pars, len(data_slices))):
                 if chunk:
                     res.extend(chunk)
+                    pbar.update(len(chunk))
         else:
             with ProcessPoolExecutor(max_workers=min(MAX_WORKERS, args.num_workers)) as ex:
                 for chunk in ex.map(env.tokenizer.decode_batch, data_slices, repeat(pars, len(data_slices))):
                     if chunk:
                         res.extend(chunk)
+                        pbar.update(len(chunk))
     else:
         res = env.tokenizer.decode_batch(data, pars)
+        pbar.update(len(res))
     return res
 
 
@@ -50,20 +54,24 @@ def generate_and_score(args, classname):
     rem = args.gensize % BATCH
     if rem:
         batch_counts.append(rem)
-    if args.process_pool:
-        pars = classname._save_class_params()
-        with ProcessPoolExecutor(max_workers=min(MAX_WORKERS, args.num_workers)) as executor:
-            # map returns lists; stream them to avoid a giant materialization
-            for chunk in executor.map(
-                classname._batch_generate_and_score, batch_counts, repeat(args.N, len(batch_counts)), repeat(pars, len(batch_counts))
-            ):
-                if chunk:  # extend incrementally to manage memory
-                    data.extend(chunk)
-    else:
-        for t in batch_counts:
-            d = classname._batch_generate_and_score(t, args.N)
-            if d is not None:
-                data.extend(d)
+
+    with tqdm(total=args.gensize, desc="Generating data", unit="ex") as pbar:
+        if args.process_pool:
+            pars = classname._save_class_params()
+            with ProcessPoolExecutor(max_workers=min(MAX_WORKERS, args.num_workers)) as executor:
+                # map returns lists; stream them to avoid a giant materialization
+                for chunk in executor.map(
+                    classname._batch_generate_and_score, batch_counts, repeat(args.N, len(batch_counts)), repeat(pars, len(batch_counts))
+                ):
+                    if chunk:  # extend incrementally to manage memory
+                        data.extend(chunk)
+                        pbar.update(len(chunk))
+        else:
+            for t in batch_counts:
+                d = classname._batch_generate_and_score(t, args.N)
+                if d is not None:
+                    data.extend(d)
+                    pbar.update(len(d))
     return data
 
 

--- a/src/envs/environment.py
+++ b/src/envs/environment.py
@@ -114,7 +114,7 @@ def _do_score(d, always_search: bool = False, redeem_only: bool = False, pars=No
     return (d, invalid)
 
 
-def do_score(data, args, executor=None):
+def do_score(data, args, executor=None, pbar=None):
     """
     Compute the score of a list of data.
     Can be parallelized with process_pool.
@@ -128,6 +128,7 @@ def do_score(data, args, executor=None):
             res, invalid = _do_score(d, args.always_search, args.redeem_only)
             n_invalid += invalid
             processed_data.append(res)
+            pbar.update(1)
     else:
         pars = data[0]._save_class_params()
 
@@ -137,11 +138,14 @@ def do_score(data, args, executor=None):
             for d, invalid in executor.map(_do_score, data, repeat(args.always_search), repeat(args.redeem_only), repeat(pars), chunksize=chunksize):
                 processed_data.append(d)
                 n_invalid += invalid
+                pbar.update(1)
         else:
             with ProcessPoolExecutor(max_workers=args.num_workers) as ex:
                 for d, invalid in ex.map(_do_score, data, repeat(args.always_search), repeat(args.redeem_only), repeat(pars), chunksize=chunksize):
                     processed_data.append(d)
                     n_invalid += invalid
+                    pbar.update(1)
+    pbar.refresh()
 
     valid_data = [d for d in processed_data if d.score >= 0]
 

--- a/src/evaluator.py
+++ b/src/evaluator.py
@@ -6,6 +6,7 @@ from logging import getLogger
 
 import numpy as np
 import torch
+from tqdm import tqdm
 
 from src.datasets import detokenize
 from src.envs.environment import do_score, do_stats
@@ -75,46 +76,48 @@ def sample_and_score(model, args, stoi, itos, env, temp, temp_span=0):
     total_invalid = 0
     all_processed_data = []
     results_lock = threading.Lock()
+    detok_pbar = None
+    score_pbar = None
 
     executor = ProcessPoolExecutor(max_workers=min(MAX_WORKERS, args.num_workers))
 
     def process_batches(batches):
         nonlocal total_invalid
         all_data = [batch_numpy[j] for batch_numpy in batches for j in range(batch_numpy.shape[0])]
-        detok_results = detokenize(all_data, args, env, executor=executor)
-        valid_data, n_invalid, processed_data = do_score(detok_results, args=args, executor=executor)
+        detok_results = detokenize(all_data, args, env, executor=executor, pbar=detok_pbar)
+        valid_data, n_invalid, processed_data = do_score(detok_results, args=args, executor=executor, pbar=score_pbar)
         with results_lock:
             results.extend(valid_data)
             total_invalid += n_invalid
             all_processed_data.extend(processed_data)
 
-    with cpu_sink(process_batches, decouple=True) as sink:
-        pending_batches = []
+    with tqdm(total=args.num_samples_from_model, desc="Sampling", unit="ex") as sample_pbar:
+        with tqdm(total=args.num_samples_from_model, desc="Detokenizing", unit="ex") as detok_pbar:
+            with tqdm(total=args.num_samples_from_model, desc="Scoring", unit="ex") as score_pbar:
+                with cpu_sink(process_batches, decouple=True) as sink:
+                    pending_batches = []
 
-        for i in range(todo):
-            if temp_span > 0:
-                curr_temp = temp + 0.1 * np.random.randint(temp_span + 1)
-            else:
-                curr_temp = temp
-            if i % 100 == 0:
-                with results_lock:
-                    scored_so_far = len(results)
-                logger.info(f"{i*sample_batch_size} / {todo * sample_batch_size} samples generated, {scored_so_far} scored")
+                    for i in range(todo):
+                        if temp_span > 0:
+                            curr_temp = temp + 0.1 * np.random.randint(temp_span + 1)
+                        else:
+                            curr_temp = temp
 
-            X_init = torch.empty((sample_batch_size, 1), dtype=torch.long)
-            X_init[:, 0] = stoi["BOS"]
-            X_init = X_init.to(args.device)
-            top_k = args.top_k if args.top_k != -1 else None
-            batch_numpy = model.generate(X_init, args.max_len + 1, temperature=curr_temp, top_k=top_k, do_sample=True).cpu().numpy()
+                        X_init = torch.empty((sample_batch_size, 1), dtype=torch.long)
+                        X_init[:, 0] = stoi["BOS"]
+                        X_init = X_init.to(args.device)
+                        top_k = args.top_k if args.top_k != -1 else None
+                        batch_numpy = model.generate(X_init, args.max_len + 1, temperature=curr_temp, top_k=top_k, do_sample=True).cpu().numpy()
 
-            pending_batches.append(batch_numpy)
+                        pending_batches.append(batch_numpy)
+                        sample_pbar.update(sample_batch_size)
 
-            if len(pending_batches) >= DETOK_CHUNK_SIZE:
-                sink.submit(pending_batches)
-                pending_batches = []
+                        if len(pending_batches) >= DETOK_CHUNK_SIZE:
+                            sink.submit(pending_batches)
+                            pending_batches = []
 
-        if pending_batches:
-            sink.submit(pending_batches)
+                    if pending_batches:
+                        sink.submit(pending_batches)
 
     executor.shutdown(wait=True)
 


### PR DESCRIPTION
# What?
Adds a `tqdm` progress bar for several steps:
- data generation
- sampling
- detokenization
- scoring

# Why?

Added a progress bar in my fork after checking on a job after 10h and seeing it stuck on data generation.

# "Testing"

Ran axplorer locally, verified the progress bars showed up.

### Data generation, ongoing

<img width="1695" height="353" alt="image" src="https://github.com/user-attachments/assets/0d46da41-a41a-4103-9afe-a86dbb874af0" />

### Data generation, finished

<img width="1695" height="353" alt="image" src="https://github.com/user-attachments/assets/fced618d-cf3b-4df9-80aa-51d70cad9578" />

### Sampling + detokenization + scoring, ongoing

<img width="1695" height="163" alt="image" src="https://github.com/user-attachments/assets/d416b279-d62e-460a-9671-8e1bb26167a6" />

### Sampling + detokenization + scoring, finished

<img width="1695" height="353" alt="image" src="https://github.com/user-attachments/assets/77ddf287-ed32-4fee-8e7b-7be21dccccf1" />

# LLM Usage
Code written by @claude and reviewed by me. 
Code "tested" by me.

PR message written by me.