### PR TITLE
fix DenseTokenizer not initializing self.extra_symbols

### DIFF
--- a/src/envs/tokenizers.py
+++ b/src/envs/tokenizers.py
@@ -180,6 +180,7 @@ class DenseTokenizer(Tokenizer):
         self.pow2base = pow2base
         self.encoding_augmentation = encoding_augmentation
         self.stoi, self.itos = {}, {}
+        self.extra_symbols = extra_symbols
 
         self.expected_elements_in_a_decoded_sequence = math.ceil(count_index_tuples(N, self.k, self.are_coordinates_symmetric) / self.pow2base)
 


### PR DESCRIPTION
referenced here https://github.com/AxiomMath/axplorer/blob/cefb3764466d5977abe984d298c1b2c12c58489f/src/envs/tokenizers.py#L242